### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/database/hall2operations.py
+++ b/database/hall2operations.py
@@ -135,7 +135,7 @@ class HallSymbol:
             G2_R, G2_T = self.__get_group( r, t )
             G_R, G_T = self.__multiply_groups( G_R, G_T, G2_R, G2_T )
 
-        if not self.V == None:
+        if not self.V is None:
             G_T = self.__change_of_basis( G_R, G_T )
 
         G_R_conventional = []
@@ -205,7 +205,7 @@ class HallSymbol:
             R.append( rot )
 
             trans = np.zeros( 3, dtype=float )
-            if N[3] != None:
+            if N[3] is not None:
                 for t in N[3]:
                     if t == '1' or t == '2' or t == '3' or t == '4' or t == '5':
                         trans_screw = float( t ) / int( N[1] )
@@ -270,7 +270,7 @@ class HallSymbol:
                     R = '2pp'
                     A = 'z'
                     N = N[2:]
-            if i == 1 and A == None:
+            if i == 1 and A is None:
                 if precededN == 2 or precededN == 4:   # 2x
                     R = '2'
                     A = 'x'
@@ -290,7 +290,7 @@ class HallSymbol:
                     A = '*'
                     N = N[2:]
 
-        if A == None:
+        if A is None:
             R = N[0]
             N = N[1:]
             if len( N ) > 0 and i == 0:

--- a/python/test/oldtest/test_stabilized_reciprocal_mesh.py
+++ b/python/test/oldtest/test_stabilized_reciprocal_mesh.py
@@ -16,12 +16,12 @@ parser.add_option("-q", "--qpoints", dest="qpoints",
                   type="string",help="Stabilizers")
 (options, args) = parser.parse_args()
 
-if options.mesh == None:
+if options.mesh is None:
   mesh = [4, 4, 4]
 else:
   mesh = [int( x ) for x in options.mesh.split()]
 
-if options.qpoints == None:
+if options.qpoints is None:
   qpoints = np.array([[0, 0, 0]], dtype=float)
 else:
   qpoints = np.array([float(x) for x in options.qpoints.split()]).reshape(-1, 3)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jochym:spglib?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:jochym:spglib?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
